### PR TITLE
(DIO-3163) Implement Cloud DNS for EC2 VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,16 @@ These steps expect two environment vars
 ### DNS
 AWS will setup a private ip and private dns hostname for the VM once running. Optionally we can setup a human readable DNS entry to resolve the VMPooler provider `spicy-proton` fqdn
 
-DNS is integrated via Google's CloudDNS service. To enable, a CloudDNS zone name must be provided in the config (see the example yaml file dns_zone_resource_name)
+DNS is integrated via Google's CloudDNS service.
+GCE authorization is handled via a service account (or personal account) private key (json format) and can be configured via
+
+1. GOOGLE_APPLICATION_CREDENTIALS environment variable eg GOOGLE_APPLICATION_CREDENTIALS=/my/home/directory/my_account_key.json
+
+Provider config needed:
+1. domain
+2. project
+3. dns_zone_resource_name
+(see the example yaml file)
 
 An A record is then created in that zone upon instance creation with the VM's internal IP, and deleted when the instance is destroyed.
 
@@ -44,8 +53,7 @@ do not have the pool label, and can be configured to allow a specific list of un
 ### Pre-requisite
 
 - An IAM user must exist in the target AWS account with permissions to create, delete vms etc
-- if using DNS, a DNS zone needs to be created in CloudDNS, and configured in the provider's config section with the name of that zone (dns_zone_resource_name). When not specified, the DNS setup and teardown is skipped.
-
+- if using DNS see section above, and a service account with permissions to change Cloud DNS need to exist
 
 ## License
 

--- a/lib/vmpooler/providers/ec2.rb
+++ b/lib/vmpooler/providers/ec2.rb
@@ -267,6 +267,7 @@ module Vmpooler
           @logger.log('s', "[>] [#{pool_name}] '#{new_vmname}' instance ready to accept traffic")
           created_instance = get_vm(pool_name, new_vmname)
 
+          @redis.hset("vmpooler__vm__#{new_vmname}", 'host', created_instance['name'])
           # extra setup steps
           provision_node_aws(created_instance['private_dns_name'], pool_name, new_vmname) if to_provision(pool_name) == 'true' || to_provision(pool_name) == true
 

--- a/lib/vmpooler/providers/ec2.rb
+++ b/lib/vmpooler/providers/ec2.rb
@@ -276,10 +276,14 @@ module Vmpooler
           @redis.with_metrics do |redis|
             redis.hset("vmpooler__vm__#{new_vmname}", 'host', created_instance['private_dns_name'])
           end
-          # extra setup steps
-          provision_node_aws(created_instance['private_dns_name'], pool_name, new_vmname) if to_provision(pool_name) == 'true' || to_provision(pool_name) == true
 
-          dns_setup(created_instance) if domain
+          if domain
+            dns_setup(created_instance)
+            provision_node_aws(created_instance['name'], pool_name, new_vmname) if to_provision(pool_name) == 'true' || to_provision(pool_name) == true
+          elsif to_provision(pool_name) == 'true' || to_provision(pool_name) == true
+            provision_node_aws(created_instance['private_dns_name'], pool_name, new_vmname)
+          end
+
           created_instance
         end
 

--- a/lib/vmpooler/providers/ec2.rb
+++ b/lib/vmpooler/providers/ec2.rb
@@ -196,11 +196,11 @@ module Vmpooler
 
           subnet_id = get_subnet_id(pool_name)
           domain_set = domain
-          if domain_set.nil?
-            name_to_use = new_vmname
-          else
-            name_to_use = "#{new_vmname}.#{domain_set}"
-          end
+          name_to_use = if domain_set.nil?
+                          new_vmname
+                        else
+                          "#{new_vmname}.#{domain_set}"
+                        end
 
           tag = [
             {
@@ -216,7 +216,7 @@ module Vmpooler
                 },
                 {
                   key: 'lifetime', # required by AWS reaper
-                  value: get_max_lifetime
+                  value: max_lifetime
                 },
                 {
                   key: 'created_by', # required by AWS reaper
@@ -479,7 +479,7 @@ module Vmpooler
         end
 
         # returns max_lifetime_upper_limit in hours in the format Xh defaults to 12h
-        def get_max_lifetime
+        def max_lifetime
           max_hours = global_config[:config]['max_lifetime_upper_limit'] || '12'
           "#{max_hours}h"
         end
@@ -498,11 +498,11 @@ module Vmpooler
           return nil if pool_configuration.nil?
 
           domain_set = domain
-          if domain_set.nil?
-            name_to_use = vm_object.private_dns_name
-          else
-            name_to_use = vm_object.tags.detect { |f| f.key == 'Name' }&.value
-          end
+          name_to_use = if domain_set.nil?
+                          vm_object.private_dns_name
+                        else
+                          vm_object.tags.detect { |f| f.key == 'Name' }&.value
+                        end
 
           {
             'name' => name_to_use,

--- a/lib/vmpooler/providers/ec2.rb
+++ b/lib/vmpooler/providers/ec2.rb
@@ -64,23 +64,26 @@ module Vmpooler
 
         # main configuration options
         def region
-          provider_config['region'] if provider_config['region']
+          provider_config['region']
         end
 
         # main configuration options, overridable for each pool
         def zone(pool_name)
           return pool_config(pool_name)['zone'] if pool_config(pool_name)['zone']
-          provider_config['zone'] if provider_config['zone']
+
+          provider_config['zone']
         end
 
         def amisize(pool_name)
           return pool_config(pool_name)['amisize'] if pool_config(pool_name)['amisize']
-          provider_config['amisize'] if provider_config['amisize']
+
+          provider_config['amisize']
         end
 
         def volume_size(pool_name)
           return pool_config(pool_name)['volume_size'] if pool_config(pool_name)['volume_size']
-          provider_config['volume_size'] if provider_config['volume_size']
+
+          provider_config['volume_size']
         end
 
         # dns
@@ -107,7 +110,7 @@ module Vmpooler
         end
 
         def to_provision(pool_name)
-          pool_config(pool_name)['provision'] if pool_config(pool_name)['provision']
+          pool_config(pool_name)['provision']
         end
 
         # Base methods that are implemented:
@@ -427,17 +430,17 @@ module Vmpooler
           return false if vm_hash.nil?
 
           filters = [{
-                       name: 'tag:vm_name',
-                       values: [vm_name]
-                     }]
+            name: 'tag:vm_name',
+            values: [vm_name]
+          }]
           instances = connection.instances(filters: filters).first
           return false if instances.nil?
 
           # add new label called token-user, with value as user
-          instances.create_tags(tags:[key:"token-user", value: user])
+          instances.create_tags(tags: [key: 'token-user', value: user])
           true
         rescue StandardError => _e
-          return false
+          false
         end
 
         # END BASE METHODS

--- a/spec/unit/providers/ec2_spec.rb
+++ b/spec/unit/providers/ec2_spec.rb
@@ -88,7 +88,8 @@ EOT
       }
       skip 'gets a vm' do
         result = subject.create_vm(poolname, vmname)
-        result = subject.destroy_vm(poolname, vmname)
+        subject.tag_vm_user(poolname, vmname)
+        #result = subject.destroy_vm(poolname, vmname)
         #subject.vms_in_pool("amazon-6-x86_64-ec2")
         #subject.provision_node_aws("ip-10-227-4-97.amz-dev.puppet.net", poolname)
         # subject.create_snapshot(poolname, vmname, "foo")
@@ -160,7 +161,7 @@ EOT
     context 'when VM exists but is missing information' do
       before(:each) do
         tags = [
-          MockTag.new(key: "name", value: vmname),
+          MockTag.new(key: "Name", value: vmname),
           MockTag.new(key: "vm_name", value: vmname)
         ]
         allow(connection).to receive(:instances).and_return([MockInstance.new(tags: tags)])
@@ -170,7 +171,8 @@ EOT
         expect(subject.get_vm(poolname, vmname)).to be_kind_of(Hash)
       end
 
-      it 'should return the VM name' do
+      it 'should return the VM name when domain set' do
+        config[:providers][:ec2]['domain'] = "foobar.com"
         result = subject.get_vm(poolname, vmname)
 
         expect(result['name']).to eq(vmname)
@@ -197,7 +199,7 @@ EOT
           instance_type: "a1.large",
           private_ip_address: "1.1.1.1",
           tags: [
-                  MockTag.new(key: "name", value: vmname),
+                  MockTag.new(key: "Name", value: vmname),
                   MockTag.new(key: "pool", value: poolname)
                 ]
         )

--- a/spec/unit/providers/ec2_spec.rb
+++ b/spec/unit/providers/ec2_spec.rb
@@ -159,7 +159,10 @@ EOT
 
     context 'when VM exists but is missing information' do
       before(:each) do
-        tags = [MockTag.new(key: "vm_name", value: vmname)]
+        tags = [
+          MockTag.new(key: "name", value: vmname),
+          MockTag.new(key: "vm_name", value: vmname)
+        ]
         allow(connection).to receive(:instances).and_return([MockInstance.new(tags: tags)])
       end
 
@@ -194,7 +197,7 @@ EOT
           instance_type: "a1.large",
           private_ip_address: "1.1.1.1",
           tags: [
-                  MockTag.new(key: "vm_name", value: vmname),
+                  MockTag.new(key: "name", value: vmname),
                   MockTag.new(key: "pool", value: poolname)
                 ]
         )
@@ -328,6 +331,8 @@ EOT
         allow(connection).to receive(:client).and_return(client)
         allow(client).to receive(:wait_until)
         allow(instance).to receive(:id)
+        allow(subject).to receive(:get_vm).and_return({})
+        allow(subject).to receive(:dns_teardown).and_return(true)
       end
 
       it 'should return true' do

--- a/spec/unit/providers/ec2_spec.rb
+++ b/spec/unit/providers/ec2_spec.rb
@@ -53,23 +53,28 @@ EOT
 
   describe '#manual tests live' do
     context 'in itsysops' do
-      let(:vmname) { "instance-50" }
-      let(:poolname) { "ubuntu-2004-arm64" }
+      let(:vmname) { "instance-60" }
+      let(:poolname) { "amazon-7-x86_64-local" }
+      let(:amisize) { "c5.xlarge" }
       let(:config) { YAML.load(<<~EOT
   ---
   :config:
     max_tries: 3
     retry_factor: 10
+    site_name: 'vmpooler-local-dev'
   :providers:
     :ec2:
       connection_pool_timeout: 1
       zone: '#{zone}'
       region: '#{region}'
+      project: 'vmpooler-test'
+      dns_zone_resource_name: 'vmpooler-test-puppet-net'
+      domain: 'vmpooler-test.puppet.net'
   :pools:
     - name: '#{poolname}'
       alias: [ 'mockpool' ]
-      amisize: 'a1.large'
-      template: 'ami-03c1b544a7566b3e5'
+      amisize: '#{amisize}'
+      template: 'ami-31394949'
       size: 5
       timeout: 10
       ready_ttl: 1440
@@ -83,6 +88,7 @@ EOT
       }
       skip 'gets a vm' do
         result = subject.create_vm(poolname, vmname)
+        result = subject.destroy_vm(poolname, vmname)
         #subject.vms_in_pool("amazon-6-x86_64-ec2")
         #subject.provision_node_aws("ip-10-227-4-97.amz-dev.puppet.net", poolname)
         # subject.create_snapshot(poolname, vmname, "foo")

--- a/vmpooler-provider-ec2.gemspec
+++ b/vmpooler-provider-ec2.gemspec
@@ -16,9 +16,11 @@ Gem::Specification.new do |s|
   s.files         = Dir[ "lib/**/*" ]
   s.require_paths = ["lib"]
   s.add_dependency 'aws-sdk-ec2', '~> 1'
-  s.add_dependency 'net-ssh', '~> 6.2.0.rc2'
+  s.add_dependency 'net-ssh', '>= 6.2', '< 7.1'
   
   s.add_development_dependency 'vmpooler', '>= 1.3.0', '~> 2.3'
+  #s.add_development_dependency 'vmpooler-provider-gce', '>= 0.4.0', '~> 0.4'
+  s.add_development_dependency 'vmpooler-provider-gce', '>= 0.4.0', '~> 0.4'
 
   # Testing dependencies
   s.add_development_dependency 'climate_control', '>= 0.2.0'

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -81,7 +81,10 @@
 #     Overwrites the global domain parameter. This should match the dns zone domain set for the dns_zone_resource_name.
 #     It is used to infer the domain part of the FQDN ie $vm_name.$domain
 #     When setting multiple providers at the same time, this value should be set for each GCE pools.
-#     (optional) If not explicitely set, the FQDN is inferred using the global 'domain' config parameter
+#     (optional) when not set, the dns setup / teardown is skipped and the instance is reachable via the private_dns_name
+#   - project
+#     The GCP project name where the DNS zone resource exists
+#     (optional)
 # Example:
 
   :aws:
@@ -91,6 +94,7 @@
     volume_size: '10'
     dns_zone_resource_name: 'subdomain-example-com'
     domain: 'subdomain.example.com'
+    project: 'gcp-project-1'
 
 # :pools:
 #


### PR DESCRIPTION
This provider now depends on the gce provider for its dns setup class. That class is required and used whenever a domain key is set. A project and dns resource name also needs to be specified for the DNS implementation, as well as the authentication via GOOGLE_APPLICATION_CREDENTIALS

The AWS  VM tag 'Name' is set to the spicy-proton name (including domain if set) which is shown in the AWS EC2 console when listing VMs

The 'lifetime' tag is set to the max_lifetime_upper_limit as per global config or 12h - this tag is used by our off band  AWS VM reaper. The lifecycle management is done by VMPooler so this limit is a failsafe mechanism.

We now set the 'host' key in redis for the VM information "vmpooler__vm__#{new_vmname}" which can be retrieved via the API and will now show in floaty query. The key is set to the private dns name of the VM, in case this information is needed. 

Updating the net:ssh library version as it seems to work when tested locally.

